### PR TITLE
Allow CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.16)
 
 
 
@@ -31,7 +31,7 @@ endif()
 
 # Library dependencies
 
-find_package(Python3 COMPONENTS Interpreter Development.Module)
+find_package(Python3 COMPONENTS Interpreter Development)
 
 if(${Python3_FOUND})
 	message(STATUS "Building Python module")


### PR DESCRIPTION
I need to get sharedstructures to build on Ubuntu 20.04, which only gives me CMake 3.16. With this patch the library builds for me.